### PR TITLE
Refactor cluster scripts to use GitHub sync instead of rsync

### DIFF
--- a/scripts/cluster/remote_evaluate.sh
+++ b/scripts/cluster/remote_evaluate.sh
@@ -102,8 +102,18 @@ echo "Num samples: $NUM_SAMPLES"
 echo "Device: $DEVICE"
 echo ""
 
-# Upload config file to cluster
-echo "Step 1: Uploading config file..."
+# Sync code from GitHub
+echo "Step 1: Syncing code from GitHub..."
+sshpass -p "$PASSWORD" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    "$HOST" "cd ~/giblet-responses && source ~/.bashrc && source scripts/cluster/setup_cluster.sh && setup_cluster_environment" || {
+    echo "Error: Failed to sync code from GitHub"
+    exit 1
+}
+echo "✓ Code synced from GitHub"
+
+# Upload config file to cluster (config files may not be committed to git)
+echo ""
+echo "Step 2: Uploading config file..."
 sshpass -p "$PASSWORD" scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     "$CONFIG" "$HOST:~/giblet-responses/$(basename $CONFIG)" || {
     echo "Error: Failed to upload config file"
@@ -113,7 +123,7 @@ echo "✓ Config uploaded"
 
 # Create evaluation script on cluster
 echo ""
-echo "Step 2: Creating evaluation script on cluster..."
+echo "Step 3: Creating evaluation script on cluster..."
 
 EVAL_SCRIPT=$(cat <<'EOF'
 #!/bin/bash
@@ -166,7 +176,7 @@ echo "✓ Evaluation script created"
 
 # Run evaluation
 echo ""
-echo "Step 3: Running evaluation on $CLUSTER..."
+echo "Step 4: Running evaluation on $CLUSTER..."
 echo "This may take several minutes..."
 echo ""
 
@@ -181,7 +191,7 @@ sshpass -p "$PASSWORD" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/de
 # Sync results back if requested
 if [ "$SYNC_RESULTS" = true ]; then
     echo ""
-    echo "Step 4: Syncing results back to local machine..."
+    echo "Step 5: Syncing results back to local machine..."
 
     LOCAL_OUTPUT_DIR="$OUTPUT_DIR"
     mkdir -p "$LOCAL_OUTPUT_DIR"


### PR DESCRIPTION
## Summary
Replaces rsync-based code syncing with GitHub-based workflow for all cluster scripts.

## Changes

### Created: `scripts/cluster/setup_cluster.sh`
- **Centralized idempotent setup function** for all cluster scripts
- Clones/updates repo from `ContextLab/giblet-responses` (upstream)
- Downloads Sherlock dataset if needed (11GB, checks for 15+ .nii.gz files)
- Creates conda environment `giblet-py311` if missing
- Installs dependencies from `requirements.txt`
- All operations are **re-runnable** and safe (idempotent)
- Color-coded output with clear success/warning/error messages

### Updated: `scripts/cluster/remote_train.sh`
- **Removed**: All rsync operations for code syncing
- **Added**: GitHub sync via `setup_cluster_environment()` function call
- **Kept**: All existing functionality (screen sessions, training, monitoring, etc.)

### Updated: `scripts/cluster/remote_evaluate.sh`
- **Added**: GitHub sync step (new Step 1) before evaluation
- **Kept**: rsync for syncing reconstruction results BACK to local machine (correct - results are too large for git)
- **Updated**: Step numbering in output messages

## Benefits of GitHub Sync

1. **Version Control**: All code changes tracked in git history
2. **Atomic Updates**: Hard reset ensures clean state every time
3. **No Conflicts**: Untracked files automatically cleaned
4. **Faster**: No SSH file transfer needed
5. **Reliable**: GitHub is single source of truth
6. **Reproducible**: Exact same code on local and remote

## Usage

**Before running cluster scripts, always commit and push to origin:**
```bash
git add .
git commit -m "Update training code"
git push origin main
# Wait for merge to upstream
```

**Then run cluster scripts as normal:**
```bash
# Training
./scripts/cluster/remote_train.sh --cluster tensor02 --gpus 6

# Evaluation
./scripts/cluster/remote_evaluate.sh --cluster tensor02 --checkpoint path/to/checkpoint.pt
```

## Testing

Scripts have been tested locally and are ready for cluster deployment once merged. After merge, user will test on actual cluster.

## Related Issues

Closes #33  
Closes #34  

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>